### PR TITLE
Remove global variables and check for API errors

### DIFF
--- a/ffi.lua
+++ b/ffi.lua
@@ -183,13 +183,13 @@ ncclResult_t ncclAllGather(const void* sendbuff, int count, ncclDataType_t datat
 
 
 
-local ok,err = pcall(function() nccl.C = ffi.load('libnccl') end)
+local ok, res = pcall(ffi.load, 'libnccl')
 if not ok then
-   print(err)
+   print(res)
    error([['libnccl.so not found in library path.
 Please install nccl. 
 Then make sure all the files named as libnccl.so* are placed in your library load path (for example /usr/local/lib , or manually add a path to LD_LIBRARY_PATH)
 ]])
 end
 
-
+return res

--- a/init.lua
+++ b/init.lua
@@ -1,68 +1,72 @@
 require 'cutorch'
-nccl = {}
-include 'ffi.lua'
-local C = nccl.C
 local ffi = require 'ffi'
 
+local nccl = {}
+_G.nccl = nccl
 
+nccl.C = dofile 'ffi.lua'
 nccl.communicators = {}
 
-function nccl.createCommunicators(devices)    
-   assert(type(devices)=='number' or torch.typename(devices) == 'torch.IntTensor', "argument type not supported")
-   if type(devices)=='number' then
-      local devicestensor=torch.IntTensor(devices)
-      for i=1,devices do devicestensor[i]=i-1 end
-      devices = devicestensor       
-   end       
---   local ind=0
-   local ind = ""
-   for i=1,devices:nElement() do ind = ind..string.format("%02d",devices[i]) end  -- ind = ind + 2^devices[i] end
-   if not nccl.communicators[ind] then      
-      --create communicator and register its garbage collector
-      nccl.communicators[ind]=ffi.new('struct ncclComm*[?]',devices:nElement())
-      local function destroy(communicators)
-         for i=1,devices:nElement() do
-             C['ncclCommDestroy'](nccl.communicators[i])
-         end
-      end
-      ffi.gc(nccl.communicators[ind],destroy)
-      C['ncclCommInitAll'](nccl.communicators[ind],devices:nElement(),devices:data())
---      local function destroyComm(d)
---         C['ncclCommDestroy'](d[0])
---      end
---      ffi.gc(nccl.communicators[ind], destroyComm)
-   end  
-   return nccl.communicators[ind]
+local function errcheck(name, ...)
+   local res = nccl.C[name](...)
+   if res ~= 'ncclSuccess' then
+      local msg = ffi.string(nccl.C.ncclGetErrorString(res))
+      error(msg .. ' (nccl.' .. name .. ')')
+   end
+   return res
 end
 
+function nccl.createCommunicators(devices)
+   if type(devices) == 'number' then
+      devices = torch.range(0, devices-1):int()
+   end
+   assert(torch.type(devices) == 'torch.IntTensor', 'argument type not supported')
 
+   local nDevices = devices:nElement()
+   local key = table.concat(devices:totable(), ',')
 
+   if not nccl.communicators[key] then
+      --create communicator and register its garbage collector
+      local comm = ffi.new('ncclComm_t[?]', nDevices)
+      errcheck('ncclCommInitAll', comm, nDevices, devices:data())
+      ffi.gc(comm, function(c)
+         for i=0,nDevices-1 do
+            nccl.C.ncclCommDestroy(c[i])
+         end
+      end)
+      nccl.communicators[key] = comm
+   end
+
+   return nccl.communicators[key]
+end
 
 --TODO - make sure order of the GPUs is checked in the communicator
 --TODO allow to use empty or wrong size outputs, as long as they are on the correct GPU
 --TODO check the sizes of all the tensors
 
-local function getComm(inputs,outputs,outtoinputsizeratio)   
-   local ind=0
-   local devices = torch.IntTensor(#inputs)         
+local function getComm(inputs, outputs)
+   local devices = torch.IntTensor(#inputs)
    for i,v in ipairs(inputs) do
-      local curdevice=v:getDevice()    
-      ind = ind + 2^(curdevice-1)      
-      devices[i]=curdevice - 1 --zero-based for cuda
-   end      
---try to find existing communicator
-   comm=nccl.communicators[ind] or nccl.createCommunicators(devices)  
-   return comm,devices
+      local device = v:getDevice()
+      if outputs then
+         assert(outputs[i]:getDevice() == device, 'input and output not on same device')
+      end
+      devices[i] = device-1 --zero-based for cuda
+   end
+
+   local comms = nccl.createCommunicators(devices)
+   return comms, devices
 end
 
-local function checkroot(root,ntensors)
-  if root and root >= 1 and root <= ntensors then
-     return root
-  else
-    return 1
-  end
+local function checkroot(root, ntensors)
+  if root == nil then return 1 end
+  assert(root >= 1 and root <= ntensors, 'invalid root: ' .. tostring(root))
+  return root
 end
 
+local function cudaStream()
+   return ffi.C.THCState_getCurrentStream(cutorch.getState())
+end
 
 local function synchronize(devices)
    for i = 1, devices:nElement() do
@@ -71,83 +75,77 @@ local function synchronize(devices)
    end
 end
 
-function nccl.allReduce(inputs, outputs, async)  
-   curDevice = cutorch.getDevice() 
-   comm,devices = getComm(inputs,outputs,1)
-   count = inputs[1]:nElement()
+function nccl.allReduce(inputs, outputs, async)
+   local curDevice = cutorch.getDevice()
+   local comm, devices = getComm(inputs, outputs)
+   local count = inputs[1]:nElement()
    outputs = outputs or inputs
    for i=1,#inputs do
       cutorch.setDevice(devices[i]+1)
-      stream = ffi.C.THCState_getCurrentStream(cutorch.getState())
-      C.ncclAllReduce(inputs[i]:data(),outputs[i]:data(),count,'ncclFloat','ncclSum',
-         comm[i-1],stream) 
-   end   
-   if not async then synchronize(devices) end
-   cutorch.setDevice(curDevice)   
-end
-
-function nccl.reduce(inputs,outputs,async,root)
-   curDevice = cutorch.getDevice() 
-   comm,devices = getComm(inputs,outputs,1)
-   root = checkroot(root, #inputs)
-   count = inputs[1]:nElement()
-   outputs = outputs or inputs   
-   for i=1,#inputs do
-      cutorch.setDevice(devices[i]+1)
-      stream = ffi.C.THCState_getCurrentStream(cutorch.getState())
-      local output
-      if outputs[i] then output = outputs[i]:data() end
-      C.ncclReduce(inputs[i]:data(),output,count,'ncclFloat','ncclSum',
-      devices[root],comm[i-1],stream)
-   end
-   if not async then synchronize(devices) end
-   cutorch.setDevice(curDevice)      
-end
-
-
-function nccl.bcast(inputs,async,root)
-   curDevice = cutorch.getDevice() 
-   comm,devices = getComm(inputs,outputs,1)
-   root = checkroot(root, #inputs)
-   count = inputs[1]:nElement()   
-   for i=1,#inputs do
-      cutorch.setDevice(devices[i]+1)
-      stream = ffi.C.THCState_getCurrentStream(cutorch.getState())      
-      C.ncclBcast(inputs[i]:data(),count,'ncclFloat',devices[root],comm[i-1],stream)      
-   end
-   if not async then synchronize(devices) end
-   cutorch.setDevice(curDevice)      
-end
-
-function nccl.allGather(inputs,outputs,async)
-   curDevice = cutorch.getDevice() 
-   comm,devices = getComm(inputs,outputs,1)
-   count = inputs[1]:nElement()   
-   assert(outputs, "can not do in-place allGather")
-   for i=1,#inputs do
-      cutorch.setDevice(devices[i]+1)
-      stream = ffi.C.THCState_getCurrentStream(cutorch.getState())      
-      C.ncclAllGather(inputs[i]:data(),count,'ncclFloat',outputs[i]:data(),comm[i-1],stream)      
-   end
-   if not async then synchronize(devices) end
-   cutorch.setDevice(curDevice)      
-end
-
-
-
-function nccl.reduceScatter(inputs,outputs,async)
-   curDevice = cutorch.getDevice()
-   comm,devices = getComm(inputs,outputs,1)
-   assert(outputs, "can not do in-place reduceScatter")
-   assert(outputs[1],"output tensors should be allocated")
-   count = outputs[1]:nElement()
-   for i=1,#inputs do
-      cutorch.setDevice(devices[i]+1)
-      stream = ffi.C.THCState_getCurrentStream(cutorch.getState())
-      C.ncclReduceScatter(inputs[i]:data(),outputs[i]:data(),count, 'ncclFloat', 'ncclSum', 
-      comm[i-1],stream)
+      errcheck('ncclAllReduce', inputs[i]:data(), outputs[i]:data(), count,
+         'ncclFloat','ncclSum', comm[i-1], cudaStream())
    end
    if not async then synchronize(devices) end
    cutorch.setDevice(curDevice)
 end
 
+function nccl.reduce(inputs, outputs, async, root)
+   local curDevice = cutorch.getDevice()
+   local comm, devices = getComm(inputs, outputs)
+   local count = inputs[1]:nElement()
+   root = checkroot(root, #inputs)
+   outputs = outputs or inputs
+   for i=1,#inputs do
+      cutorch.setDevice(devices[i]+1)
+      local output = outputs[i] and outputs[i]:data() or nil
+      errcheck('ncclReduce', inputs[i]:data(), output, count, 'ncclFloat',
+         'ncclSum', root-1, comm[i-1], cudaStream())
+   end
+   if not async then synchronize(devices) end
+   cutorch.setDevice(curDevice)
+end
+
+function nccl.bcast(inputs, async, root)
+   root = checkroot(root, #inputs)
+   local curDevice = cutorch.getDevice()
+   local comm, devices = getComm(inputs)
+   local count = inputs[1]:nElement()
+   for i=1,#inputs do
+      cutorch.setDevice(devices[i]+1)
+      errcheck('ncclBcast', inputs[i]:data(), count, 'ncclFloat',
+         root-1, comm[i-1], cudaStream())
+   end
+   if not async then synchronize(devices) end
+   cutorch.setDevice(curDevice)
+end
+
+function nccl.allGather(inputs, outputs, async)
+   local curDevice = cutorch.getDevice()
+   local comm, devices = getComm(inputs, outputs)
+   local count = inputs[1]:nElement()
+   assert(outputs, "can not do in-place allGather")
+   for i=1,#inputs do
+      cutorch.setDevice(devices[i]+1)
+      errCheck('ncclAllGather', inputs[i]:data(), count, 'ncclFloat',
+         outputs[i]:data(), comm[i-1], cudaStream())
+   end
+   if not async then synchronize(devices) end
+   cutorch.setDevice(curDevice)
+end
+
+function nccl.reduceScatter(inputs, outputs, async)
+   local curDevice = cutorch.getDevice()
+   local comm, devices = getComm(inputs, outputs)
+   assert(outputs, "can not do in-place reduceScatter")
+   assert(outputs[1], "output tensors should be allocated")
+   local count = outputs[1]:nElement()
+   for i=1,#inputs do
+      cutorch.setDevice(devices[i]+1)
+      errcheck('ncclReduceScatter', inputs[i]:data(), outputs[i]:data(), count,
+         'ncclFloat', 'ncclSum', comm[i-1], cudaStream())
+   end
+   if not async then synchronize(devices) end
+   cutorch.setDevice(curDevice)
+end
+
+return nccl

--- a/test/testnccl.lua
+++ b/test/testnccl.lua
@@ -33,7 +33,7 @@ for i=1,opt.nsizes do
       inputs[i] = torch.CudaTensor(size):fill(val)
    end
    local nrep = opt.nrepetitions   
-   local outputs 
+   local outputs, result
    if opt.outOfPlace then      
       outputs = {}
       for i=1,opt.nGPU do
@@ -75,9 +75,9 @@ for i=1,opt.nsizes do
          nccl.allGather(inputs,outputs)
       end
    end
-   elapsed=tm:time().real/nrep
-   algbw = size * sizeOfFloat / elapsed * 1e-9
-   linkbw = algbw
+   local elapsed=tm:time().real/nrep
+   local algbw = size * sizeOfFloat / elapsed * 1e-9
+   local linkbw = algbw
    if opt.operation == 'allReduce' then
       linkbw = algbw * 2 * (opt.nGPU-1)/ opt.nGPU
    elseif opt.operation == 'allGather' then
@@ -91,7 +91,7 @@ for i=1,opt.nsizes do
          expected = opt.nGPU * val
       else
          expected = opt.nGPU^(nrep) * val
-      end      
+      end
    elseif opt.operation == 'bcast' or opt.operation == 'allGather' then
       expected = val
    elseif opt.operation == 'reduce' then
@@ -100,7 +100,8 @@ for i=1,opt.nsizes do
       else
          expected = val + nrep * (opt.nGPU - 1)
       end
-   end   
+   end
+   local lastGpu
    if opt.operation == 'allReduce' or opt.operation == 'allGather' or 
       opt.operation == 'bcast' then --check results on all the gpus
       lastGpu = opt.nGPU


### PR DESCRIPTION
Remove global variables, check for API errors, and some small changes:
- The ncclComm gc hook was not called on the correct communicators
- In reduce and bcast `root` did not select the correct tensor if
  the input was not in 1, 2, 3, etc. order.
- Trigger an error if the user specifies an invalid root
- Use the new-style module semantics: require 'nccl' now returns
  the nccl module
