### PR TITLE
Use require instead of dofile

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -4,7 +4,7 @@ local ffi = require 'ffi'
 local nccl = {}
 _G.nccl = nccl
 
-nccl.C = dofile 'ffi.lua'
+nccl.C = require 'nccl.ffi'
 nccl.communicators = {}
 
 local function errcheck(name, ...)


### PR DESCRIPTION
I had a mistake in the last pull request: dofile only works in the current directory, but require works here.
