### PR TITLE
Lua 5.2/ffi compatibility change

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -9,7 +9,7 @@ nccl.communicators = {}
 
 local function errcheck(name, ...)
    local res = nccl.C[name](...)
-   if res ~= 'ncclSuccess' then
+   if res ~= nccl.C.ncclSuccess then
       local msg = ffi.string(nccl.C.ncclGetErrorString(res))
       collectgarbage('restart')
       error(msg .. ' (nccl.' .. name .. ')')


### PR DESCRIPTION
LUA 5.2/ffi doesn't seem to do the automatic boxing/unboxing that luajit does, which makes the 'ncclSuccess' check fail. Tested in luajit 2.1.0 and lua 5.2 (from torch).